### PR TITLE
Explicitly require the time library

### DIFF
--- a/lib/git_snip/branch.rb
+++ b/lib/git_snip/branch.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'time'
+
 module GitSnip
   module Branch
     Row = Struct.new(:sha, :name, :date, :author, :message)


### PR DESCRIPTION
Thanks for this super-handy gem!  I use it all the time!

Recently, I started getting the following error in Ruby 2.4.1 and 2.4.2:

```
/usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/branch.rb:19:in `block in full_row': undefined method `iso8601' for 2017-10-04 16:45:16 -0700:Time (NoMethodError)
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/branch.rb:16:in `tap'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/branch.rb:16:in `full_row'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:83:in `say_branch_info'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:72:in `block in dry_run'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:71:in `yield'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:71:in `each'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:71:in `each'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:71:in `each'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:71:in `each'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:71:in `dry_run'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/lib/git_snip/cli.rb:37:in `snip'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/git_snip-0.0.4/bin/git-snip:5:in `<top (required)>'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/bin/git-snip:22:in `load'
	from /usr/local/opt/asdf/installs/ruby/2.4.1/bin/git-snip:22:in `<main>'
```

The root cause seems to be that some of the methods on `Time` are only loaded once you explicitly require `time`.

I couldn't make this fail in a test.  I'm guessing that rspec is loading `time` for us somewhere.  But I did test this manually on my system, and it resolves the issue for me.